### PR TITLE
fix(loki.source.syslog): UDP path returns EOF

### DIFF
--- a/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
+++ b/component/loki/source/syslog/internal/syslogtarget/syslogtarget_test.go
@@ -298,6 +298,7 @@ type formatFunc func(string) string
 var (
 	fmtOctetCounting = func(s string) string { return fmt.Sprintf("%d %s", len(s), s) }
 	fmtNewline       = func(s string) string { return s + "\n" }
+	fmtIdentity      = func(s string) string { return s }
 )
 
 func Benchmark_SyslogTarget(b *testing.B) {
@@ -307,7 +308,7 @@ func Benchmark_SyslogTarget(b *testing.B) {
 		formatFunc formatFunc
 	}{
 		{"tcp", protocolTCP, fmtOctetCounting},
-		{"udp", protocolUDP, fmtOctetCounting},
+		{"udp", protocolUDP, fmtIdentity},
 	} {
 		tt := tt
 		b.Run(tt.name, func(b *testing.B) {
@@ -366,8 +367,7 @@ func TestSyslogTarget(t *testing.T) {
 	}{
 		{"tcp newline separated", protocolTCP, fmtNewline},
 		{"tcp octetcounting", protocolTCP, fmtOctetCounting},
-		{"udp newline separated", protocolUDP, fmtNewline},
-		{"udp octetcounting", protocolUDP, fmtOctetCounting},
+		{"udp", protocolUDP, fmtIdentity},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
When using `loki.source.syslog` with `udp`, all messages are broken for Grafana Agent with error message 
```
msg="error parsing syslog stream" component=loki.source.syslog.syslog err="unexpected EOF"
```

ex: `logger -d -n localhost -P 1514 'test: test'` => you get the error.
Same with Docker as Syslog message producer.

The issue comes from using TCP stream framing for UDP, which is incorrect.

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated